### PR TITLE
fix: Fixed volume name and label

### DIFF
--- a/docker-compose.minio.yaml
+++ b/docker-compose.minio.yaml
@@ -42,3 +42,6 @@ services:
 
 volumes:
   minio:
+    name: ddev-${DDEV_SITENAME}-minio
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}


### PR DESCRIPTION
Prevents anonymous volumes from being recreated, and deletes the volumes on project destroy