### PR TITLE
fix: Removed port forwarding (#5)

### DIFF
--- a/docker-compose.minio.yaml
+++ b/docker-compose.minio.yaml
@@ -11,8 +11,6 @@ services:
     expose:
       - "9999:9999"
       - "9000:9000"
-    ports:
-      - "9000"
     volumes:
       - type: "volume"
         source: minio


### PR DESCRIPTION
Host exposed port prevents multiple projects to run the MinIO plugin